### PR TITLE
Added Names of Authors and contributors in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,36 @@ setup(
         "Compile fonts from sources (UFO, Glyphs) to binary (OpenType, TrueType)."
     ),
     long_description=long_description,
+    author=(
+        "fontmake authors and contributors:"
+        " James Godfrey-kittle,"
+        " Cosimo Lupo ,"
+        " Felipe Sanches,"
+        " Nikolaus Waxweiler,"
+        " Yanone ,"
+        " Behdad Esfahbod,"
+        "Jany Belluz ,"
+        " Khaled Hosny,"
+        " Just Van Rossum,"
+        " Marc Foley,"
+        "Dave Crossland ,"
+        "Misha Brukman,"
+        "Pyup-bot, "
+        "Dennis Moyogo Jacquerye,"
+        "Simon Cozens,"
+        "NFSL2001,"
+        "Bo Song,"
+        "Sascha Brawer,"
+        "Antonio Cavedoni,"
+        "Adam Twardoch,"
+        "Fabian Greffrath,"
+        "Thomas Rettig,"
+        "Chris Simpkins,"
+        "Adrien Tetar"
+    ),
+
+
+    
     long_description_content_type="text/markdown",
     url="https://github.com/googlei18n/fontmake",
     license="Apache Software License 2.0",


### PR DESCRIPTION
I was working with Pydigger API  project that tracks different projects from PYPI that shows various stats including incomplete packaging info, fontmake popped up and I decided to update the authors and contributors information.
I hope you find this useful. thanks